### PR TITLE
rdmd: Remove tango warning

### DIFF
--- a/rdmd.d
+++ b/rdmd.d
@@ -355,18 +355,6 @@ bool inALibrary(string source, string object)
         if (source.startsWith(exclusion~'.'))
             return true;
 
-    // https://issues.dlang.org/show_bug.cgi?id=13178
-    // print a warning about `tango` removal for one release cycle
-    static bool seenTango;
-    if (!seenTango && source.startsWith("tango."))
-    {
-        seenTango = true;
-        stderr.writeln(
-            "Warning: 'tango' package is no longer automatically excluded from compilation.\n" ~
-            "Warning:  modify your build script to mention --exclude=tango to keep the old behaviour"
-        );
-    }
-
     return false;
 
     // another crude heuristic: if a module's path is absolute, it's


### PR DESCRIPTION
This warning has been there for almost a year now, it was introduced by
issue #133. By now all projects should be properly updated. Also, there
is no way to disable the warning, which is triggered even for projects
that are already updated, which makes it extra annoying.