### PR TITLE
Update DustMite

### DIFF
--- a/DustMite/splitter.d
+++ b/DustMite/splitter.d
@@ -107,7 +107,7 @@ Entity loadFiles(ref string path, ParseOptions options)
 	else
 	{
 		auto set = new Entity();
-		foreach (string entry; dirEntries(path, SpanMode.breadth))
+		foreach (string entry; dirEntries(path, SpanMode.breadth).array.sort!((a, b) => a.name < b.name))
 			if (isFile(entry))
 			{
 				assert(entry.startsWith(path));


### PR DESCRIPTION
Commits:
* `edc17f1` dustmite: Don't use floating-point to calculate progress
* `e952bdc` dustmite: Make --obfuscate --keep-length results not depend on bitness
* `042fe0c` splitter: Enforce order of read files
* `e9736b5` Use UNIX line endings in --dump output
* `d0482ee` dustmite: Emit special message when reducing to empty set
* `07f05ca` dustmite: Don't attempt to reduce empty root
* `1e01585` Fix descendant counter when removing root
* `0efbe54` Add --reduce-only
* `60293fb` splitter: Don't go into an infinite loop in postProcessBlockKeywords
* `ec08b00` Add --no-redirect switch
* `955f569` Merge pull request #25 from John-Colvin/patch-2
* `14b3aca` making sure to use std.algorithm.sort, not builtin
